### PR TITLE
54 rename backend to storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ from qiskit.circuit.random import random_circuit
 from qiskit.quantum_info.random import random_pauli
 from qiskit.primitives import Estimator
 
-from purplecaffeine.core import Trial, LocalBackend
+from purplecaffeine.core import Trial, LocalStorage
 
 n_qubits = 4
 depth = 3
@@ -43,9 +43,9 @@ shots = 2000
 circuit = random_circuit(n_qubits, depth)
 obs = random_pauli(n_qubits)
 
-local_backend = LocalBackend("./")
+local_storage = LocalStorage("./")
 
-with Trial("Example trial", backend=local_backend) as trial:
+with Trial("Example trial", storage=local_storage) as trial:
     # track some parameters
     trial.add_parameter("estimator", "qiskit.primitives.Estimator")
     trial.add_parameter("depth", depth)

--- a/client/README.md
+++ b/client/README.md
@@ -34,7 +34,7 @@ from qiskit.circuit.random import random_circuit
 from qiskit.quantum_info.random import random_pauli
 from qiskit.primitives import Estimator
 
-from purplecaffeine.core import Trial, LocalBackend
+from purplecaffeine.core import Trial, LocalStorage
 
 n_qubits = 4
 depth = 3
@@ -43,9 +43,9 @@ shots = 2000
 circuit = random_circuit(n_qubits, depth)
 obs = random_pauli(n_qubits)
 
-local_backend = LocalBackend("./")
+local_storage = LocalStorage("./")
 
-with Trial("Example trial", backend=local_backend) as trial:
+with Trial("Example trial", storage=local_storage) as trial:
     # track some parameters
     trial.add_parameter("estimator", "qiskit.primitives.Estimator")
     trial.add_parameter("depth", depth)

--- a/client/purplecaffeine/__init__.py
+++ b/client/purplecaffeine/__init__.py
@@ -3,9 +3,9 @@
     :toctree: ../stubs/
 
     Trial
-    BaseBackend
-    LocalBackend
-    ApiBackend
+    BaseStorage
+    LocalStorage
+    ApiStorage
 """
 
-from .core import Trial, LocalBackend, ApiBackend, BaseBackend
+from .core import Trial, LocalStorage, ApiStorage, BaseStorage

--- a/client/purplecaffeine/core.py
+++ b/client/purplecaffeine/core.py
@@ -40,7 +40,7 @@ class Trial:
         self,
         name: str,
         uuid: Optional[str] = None,
-        backend: Optional[BaseBackend] = None,
+        storage: Optional[BaseStorage] = None,
         metrics: Optional[List[List[Union[str, float]]]] = None,
         parameters: Optional[List[List[str]]] = None,
         circuits: Optional[List[List[Union[str, QuantumCircuit]]]] = None,
@@ -65,7 +65,7 @@ class Trial:
         """
         self.uuid = uuid or str(uuid4())
         self.name = name
-        self.backend = backend or LocalBackend(path="./")
+        self.storage = storage or LocalStorage(path="./")
 
         self.metrics = metrics or []
         self.parameters = parameters or []
@@ -158,20 +158,20 @@ class Trial:
         self.tags.append(tag)
 
     def save(self):
-        """Save into Backend."""
-        self.backend.save(trial=self)
+        """Save into Storage."""
+        self.storage.save(trial=self)
 
     def read(self, trial_id: str) -> Trial:
-        """Read a trial from Backend.
+        """Read a trial from Storage.
 
         Args:
-            trial_id: if backend is the remote api, you need the trial id find in database.
+            trial_id: if storage is the remote api, you need the trial id find in database.
 
         Returns:
             Trial dict object
         """
 
-        return self.backend.get(trial_id=trial_id)
+        return self.storage.get(trial_id=trial_id)
 
     @staticmethod
     def import_from_shared_file(path) -> "Trial":
@@ -210,8 +210,8 @@ class Trial:
         self.save()
 
 
-class BaseBackend:
-    """Base backend class."""
+class BaseStorage:
+    """Base storage class."""
 
     def save(self, trial: Trial):
         """Saves given trial.
@@ -253,14 +253,14 @@ class BaseBackend:
         raise NotImplementedError
 
 
-class ApiBackend(BaseBackend):
-    """API backend class."""
+class ApiStorage(BaseStorage):
+    """API storage class."""
 
     def __init__(self, username: str, password: str, host: str):
-        """Creates backend for APIServer.
+        """Creates storage for APIServer.
 
         Example:
-            >>> backend = ApiBackend(
+            >>> storage = ApiStorage(
             >>>     host="http://localhost:8000/",
             >>>     username="admin",
             >>>     password="123"
@@ -362,15 +362,15 @@ class ApiBackend(BaseBackend):
         return trials
 
 
-class LocalBackend(BaseBackend):
-    """Local backend."""
+class LocalStorage(BaseStorage):
+    """Local storage."""
 
     def __init__(self, path: str):
-        """Creates local backend for storing trial data
+        """Creates local storage for storing trial data
         at local folder.
 
         Example:
-            >>> backend = LocalBackend("./")
+            >>> storage = LocalStorage("./")
 
         Args:
             path: path for the local storage folder
@@ -443,8 +443,8 @@ class LocalBackend(BaseBackend):
         return trials
 
 
-class S3Backend(BaseBackend):
-    """S3 backend."""
+class S3Storage(BaseStorage):
+    """S3 storage."""
 
     def __init__(
         self,
@@ -453,12 +453,12 @@ class S3Backend(BaseBackend):
         secret_access_key: Optional[str] = None,
         directory: Optional[str] = None,
     ):
-        """Storage backend for s3 buckets.
+        """Storage storage for s3 buckets.
 
         Allows to store trial data inside s3 buckets.
 
         Example:
-            >>> backend = S3Backend("my_bucket", key="<AWS_KEY>", access_key="<AWS_ACCESS_KEY>")
+            >>> storage = S3Storage("my_bucket", key="<AWS_KEY>", access_key="<AWS_ACCESS_KEY>")
 
         Args:
             bucket_name: bucket name

--- a/client/purplecaffeine/core.py
+++ b/client/purplecaffeine/core.py
@@ -41,7 +41,7 @@ class Trial:
         self,
         name: str,
         uuid: Optional[str] = None,
-        backend: Optional[BaseBackend] = None,
+        storage: Optional[BaseStorage] = None,
         description: Optional[str] = None,
         metrics: Optional[List[List[Union[str, float]]]] = None,
         parameters: Optional[List[List[str]]] = None,

--- a/client/purplecaffeine/utils/json.py
+++ b/client/purplecaffeine/utils/json.py
@@ -11,15 +11,15 @@ class TrialEncoder(RuntimeEncoder):
     """Json encoder for trial."""
 
     def default(self, obj: Any) -> Any:
-        from purplecaffeine.core import BaseBackend
+        from purplecaffeine.core import BaseStorage
 
         if isinstance(obj, Backend):
             return {
                 "__type__": "Backend",
                 "__value__": pickle.dumps(obj),
             }
-        elif isinstance(obj, BaseBackend):
-            return {"__type__": "PurpleCaffeineBackend"}
+        elif isinstance(obj, BaseStorage):
+            return {"__type__": "PurpleCaffeineStorage"}
         return super().default(obj)
 
 
@@ -32,7 +32,7 @@ class TrialDecoder(RuntimeDecoder):
 
             if obj_type == "Backend":
                 return pickle.loads(obj["__value__"])
-            elif obj_type == "PurpleCaffeineBackend":
+            elif obj_type == "PurpleCaffeineStorage":
                 # we should not recover trial backend
                 return None
             return super().object_hook(obj)

--- a/client/tests/test_backend.py
+++ b/client/tests/test_backend.py
@@ -1,76 +1,76 @@
-"""Tests for Backend."""
+"""Tests for Storage."""
 import os
 import shutil
 from pathlib import Path
 from unittest import TestCase, skip
 
-from purplecaffeine.core import Trial, LocalBackend, S3Backend, ApiBackend
+from purplecaffeine.core import Trial, LocalStorage, S3Storage, ApiStorage
 from purplecaffeine.exception import PurpleCaffeineException
 from .test_trial import dummy_trial
 
 
-class TestBackend(TestCase):
-    """TestBackend."""
+class TestStorage(TestCase):
+    """TestStorage."""
 
     def setUp(self) -> None:
-        """SetUp Backend object."""
+        """SetUp Storage object."""
         current_directory = os.path.dirname(os.path.abspath(__file__))
-        self.save_path = os.path.join(current_directory, "test_backend")
+        self.save_path = os.path.join(current_directory, "test_storage")
         if not os.path.exists(self.save_path):
             Path(self.save_path).mkdir(parents=True, exist_ok=True)
-        self.local_backend = LocalBackend(path=self.save_path)
-        self.my_trial = dummy_trial(name="keep_trial", backend=self.local_backend)
+        self.local_storage = LocalStorage(path=self.save_path)
+        self.my_trial = dummy_trial(name="keep_trial", storage=self.local_storage)
 
-    def test_save_get_list_local_backend(self):
+    def test_save_get_list_local_storage(self):
         """Test save trial locally."""
         # Save
-        self.local_backend.save(trial=self.my_trial)
+        self.local_storage.save(trial=self.my_trial)
         self.assertTrue(
             os.path.isfile(os.path.join(self.save_path, f"{self.my_trial.uuid}.json"))
         )
         # Get
-        recovered = self.local_backend.get(trial_id=self.my_trial.uuid)
+        recovered = self.local_storage.get(trial_id=self.my_trial.uuid)
         self.assertTrue(isinstance(recovered, Trial))
         self.assertEqual(recovered.parameters, [["test_parameter", "parameter"]])
         with self.assertRaises(ValueError):
-            self.local_backend.get(trial_id="999")
+            self.local_storage.get(trial_id="999")
         # List
-        list_trials = self.local_backend.list()
+        list_trials = self.local_storage.list()
         self.assertTrue(isinstance(list_trials, list))
         self.assertTrue(isinstance(list_trials[0], Trial))
 
     @skip("Remote call.")
-    def test_save_get_api_backend(self):
+    def test_save_get_api_storage(self):
         """Test save trial remotely."""
         # Save
-        backend = ApiBackend(host="", username="", password="")
-        backend.save(trial=self.my_trial)
+        storage = ApiStorage(host="", username="", password="")
+        storage.save(trial=self.my_trial)
         # Get
-        recovered = backend.get(trial_id="1")
+        recovered = storage.get(trial_id="1")
         self.assertTrue(isinstance(recovered, Trial))
         self.assertEqual(recovered.parameters, [["test_parameter", "parameter"]])
         with self.assertRaises(ValueError):
-            backend.get(trial_id="999")
+            storage.get(trial_id="999")
 
     @skip("Requires access tokens")
-    def test_save_and_load_s3_backend(self) -> None:
-        """Test of S3Backend object."""
-        s3_backend = S3Backend("bucket")
+    def test_save_and_load_s3_storage(self) -> None:
+        """Test of S3Storage object."""
+        s3_storage = S3Storage("bucket")
         # save
-        uuid = s3_backend.save(trial=self.my_trial)
+        uuid = s3_storage.save(trial=self.my_trial)
         # get
-        recovered = s3_backend.get(trial_id=uuid)
+        recovered = s3_storage.get(trial_id=uuid)
         self.assertTrue(isinstance(recovered, Trial))
         with self.assertRaises(PurpleCaffeineException):
-            s3_backend.get(trial_id="999")
+            s3_storage.get(trial_id="999")
         # list
-        list_trials = s3_backend.list()
+        list_trials = s3_storage.list()
         self.assertTrue(isinstance(list_trials, list))
         for trial in list_trials:
             self.assertTrue(isinstance(trial, Trial))
 
     def tearDown(self) -> None:
-        """TearDown Backend object."""
+        """TearDown Storage object."""
         file_to_remove = os.path.join(self.save_path)
         if os.path.exists(file_to_remove):
             shutil.rmtree(file_to_remove)

--- a/client/tests/test_trial.py
+++ b/client/tests/test_trial.py
@@ -10,18 +10,18 @@ from qiskit import QuantumCircuit
 from qiskit.circuit.library import XGate
 from qiskit.quantum_info import Operator
 
-from purplecaffeine import Trial, LocalBackend, ApiBackend, BaseBackend as TrialBackend
+from purplecaffeine import Trial, LocalStorage, ApiStorage, BaseStorage as TrialStorage
 
 
 def dummy_trial(
-    name: Optional[str] = "test_trial", backend: Optional[TrialBackend] = None
+    name: Optional[str] = "test_trial", storage: Optional[TrialStorage] = None
 ):
     """Returns dummy trial for tests.
 
     Returns:
         dummy trial
     """
-    trial = Trial(name=name, backend=backend)
+    trial = Trial(name=name, storage=storage)
     trial.add_metric("test_metric", 42)
     trial.add_parameter("test_parameter", "parameter")
     trial.add_circuit("test_circuit", QuantumCircuit(2))
@@ -42,12 +42,12 @@ class TestTrial(TestCase):
         self.save_path = os.path.join(current_directory, "resources")
         if not os.path.exists(self.save_path):
             Path(self.save_path).mkdir(parents=True, exist_ok=True)
-        self.local_backend = LocalBackend(path=self.save_path)
+        self.local_storage = LocalStorage(path=self.save_path)
 
     def test_trial_context(self):
         """Test train context."""
         uuid = "some_uuid"
-        with Trial(name="test_trial", backend=self.local_backend, uuid=uuid) as trial:
+        with Trial(name="test_trial", storage=self.local_storage, uuid=uuid) as trial:
             trial.add_metric("test_metric", 42)
         trial.read(trial_id=uuid)
         self.assertTrue(os.path.isfile(os.path.join(self.save_path, f"{uuid}.json")))
@@ -67,7 +67,7 @@ class TestTrial(TestCase):
 
     def test_save_read_local_trial(self):
         """Test save and read Trial locally."""
-        trial = dummy_trial(backend=self.local_backend)
+        trial = dummy_trial(storage=self.local_storage)
         trial.save()
 
         self.assertTrue(
@@ -85,8 +85,8 @@ class TestTrial(TestCase):
     @skip("Remote call")
     def test_save_read_api_trial(self):
         """Test save and read Trial remotely."""
-        backend = ApiBackend(username="", password="", host="")
-        trial = dummy_trial(backend=backend)
+        storage = ApiStorage(username="", password="", host="")
+        trial = dummy_trial(storage=storage)
         trial.save()
 
         recovered = trial.read(trial_id="1")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.append(os.path.abspath('../client'))
+sys.path.append(os.path.abspath("../client"))
 
 project = "PurpleCaffeine"
 copyright = "2023"  # pylint: disable=redefined-builtin

--- a/docs/guides/01_tracking_quantum_experiments.ipynb
+++ b/docs/guides/01_tracking_quantum_experiments.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "212f2f43-9592-4b2a-83a2-77009fd42ecc",
    "metadata": {},
@@ -11,7 +12,7 @@
     "\n",
     "First we introduce glossary:\n",
     "- `Trial` is a tracking class which wraps a single execution of your quantum experiment\n",
-    "- `Backend` is a class responsible for storing trial data\n",
+    "- `Storage` is a class responsible for storing trial data\n",
     "\n",
     "We will show simple example of measuring expectation value of an observable and how to track all information about this experiment.\n",
     "\n",
@@ -29,10 +30,11 @@
     "from qiskit.quantum_info.random import random_pauli\n",
     "from qiskit.primitives import Estimator\n",
     "\n",
-    "from purplecaffeine.core import Trial, LocalBackend"
+    "from purplecaffeine.core import Trial, LocalStorage"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0e71e4ac-e636-48d6-89ac-8873da516f40",
    "metadata": {},
@@ -108,12 +110,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8ae87bf1-7706-4327-90f0-3ae3f609cc5b",
    "metadata": {},
    "source": [
     "We also need a place where we will store data about our trials. \n",
-    "In this example we will be using `LocalBackend` which stores information locally in a folder that you configured.\n",
+    "In this example we will be using `LocalStorage` which stores information locally in a folder that you configured.\n",
     "We will set our folder for trials to be `./trials`."
    ]
   },
@@ -124,18 +127,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "local_backend = LocalBackend(\"./trials\")"
+    "local_storage = LocalStorage(\"./trials\")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e441d87a-26eb-47d3-aab0-1d52ff9fcb88",
    "metadata": {},
    "source": [
-    "In order to track our actions we need to work with `Trial` class, give it a name `Example trial`, pass our `local_backend` as backend option and start context (python `with` statement).\n",
+    "In order to track our actions we need to work with `Trial` class, give it a name `Example trial`, pass our `local_storage` as storage option and start context (python `with` statement).\n",
     "\n",
     "Within this context we can call list of different methods on `trial` object. Some of them are:\n",
-    "- `add_parameter` adds parameters to the trial, which can be backend names, depth, number of qubits, etc.\n",
+    "- `add_parameter` adds parameters to the trial, which can be storage names, depth, number of qubits, etc.\n",
     "- `add_metric` adds metric to the trial, which can represent measurable outcome of this trial. Ex: history of vqe iterations, results of measurement, etc.\n",
     "- `add_circuit` adds circuit to the trial to understand what circuits where used in your work\n",
     "- `add_operator` adds operator to the trial  to understand what observables/operators where used in your work"
@@ -148,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with Trial(\"Example trial\", backend=local_backend) as trial:\n",
+    "with Trial(\"Example trial\", storage=local_storage) as trial:\n",
     "    # track some parameters\n",
     "    trial.add_parameter(\"estimator\", \"qiskit.primitives.Estimator\")\n",
     "    trial.add_parameter(\"depth\", depth)\n",
@@ -167,11 +171,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "87e881b8-4c1a-4ea5-bbaa-6a20a10d956d",
    "metadata": {},
    "source": [
-    "We can get list of all experiments by calling `list` method on backend object."
+    "We can get list of all experiments by calling `list` method on storage object."
    ]
   },
   {
@@ -195,15 +200,16 @@
     }
    ],
    "source": [
-    "local_backend.list()"
+    "local_storage.list()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6e368613-4622-48ee-8e65-d78930eef055",
    "metadata": {},
    "source": [
-    "We can quiery existing experiments by name by calling `get` method on backend object and passing name of your example"
+    "We can quiery existing experiments by name by calling `get` method on storage object and passing name of your example"
    ]
   },
   {
@@ -224,7 +230,7 @@
     }
    ],
    "source": [
-    "local_backend.get(\"88b5ef54-a66b-45e1-aed8-c7db7ad82594\")"
+    "local_storage.get(\"88b5ef54-a66b-45e1-aed8-c7db7ad82594\")"
    ]
   }
  ],

--- a/docs/paper/paper.md
+++ b/docs/paper/paper.md
@@ -77,7 +77,7 @@ analyses, reproducible research, and accelerated progress in the field.
 # Architecture
 
 The proposed software package utilizes a variation of the client-server 
-architecture, consisting of a client-side component and multiple backend 
+architecture, consisting of a client-side component and multiple storage 
 options for storing experimental data \autoref{fig:architecture}.
 
 ![Architecture.\label{fig:architecture}](./images/architecture.png)
@@ -87,22 +87,22 @@ The client component is a Python library specifically designed for
 tracking experimental data in quantum computing research, covering essential
 Qiskit [@Qiskit] objects like QuantumCircuit, Operators, Backends, etc.
 
-To cater to diverse needs, the package provides three flavors of backend 
+To cater to diverse needs, the package provides three flavors of storage 
 options for storing experimental data:
-1. Local Backend: The local backend allows researchers to store 
+1. Local Storage: The local storage allows researchers to store 
     their experimental data locally on their machines. 
     This option offers convenience and data privacy, as 
     researchers have direct control over their data storage. 
     It is an excellent choice for individual researchers or 
     small-scale projects where data sharing and collaboration 
     are not a primary concern. 
-2. API Backend: The API backend is a RESTful API service that  
+2. API Storage: The API storage is a RESTful API service that  
     functions as a multi-tenant storage solution. 
-    Researchers can utilize this backend to store their experimental 
+    Researchers can utilize this storage to store their experimental 
     data in a centralized and scalable manner. 
     It is particularly beneficial for collaborative research projects or 
     environments where data sharing and team collaboration are essential. 
-3. S3 Backend: The S3 backend provides the option to store experimental 
+3. S3 Storage: The S3 storage provides the option to store experimental 
     data in S3 buckets, which are highly scalable and reliable storage 
     containers. Researchers can leverage the power and versatility of 
     S3 to securely store and access their experimental data. 
@@ -124,10 +124,10 @@ they want to gather and track. It acts as a blueprint for capturing information
 such as experimental parameters, circuit configurations, measurement results, 
 and any other relevant data points.
 
-2. Backend: The Backend abstraction is responsible for the storage functionality 
+2. Storage: The Storage abstraction is responsible for the storage functionality 
 of the software. It provides a unified interface to store and retrieve experimental 
-data. The software offers three different flavors of backend options, as previously
-discussed: local backend, API backend, and S3 backend.
+data. The software offers three different flavors of storage options, as previously
+discussed: local storage, API storage, and S3 storage.
 
 3. Widget: The Widget \autoref{fig:widget} is a visualization tool that enhances the user experience by acting 
 as a user interface for searching, viewing, and analyzing previous trials. 


### PR DESCRIPTION
Rename `backend` to `Storage` in the project

### Summary
- [X] Renamed Client core
- [X] Renamed Client test
- [X] Updated Doc
- [ ] Update Filenames